### PR TITLE
Updated Dockerfile for latest discord download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN wget https://dl.discordapp.net/apps/linux/0.0.4/discord-0.0.4.tar.gz -O /tmp/discord.tar.gz && \
+RUN wget https://discordapp.com/api/download?platform=linux&format=tar.gz -O /tmp/discord.tar.gz && \
     cd /tmp/ && \
     tar xvzf /tmp/discord.tar.gz && \
     rm /etc/fonts/conf.d/10-scale-bitmap-fonts.conf && \


### PR DESCRIPTION
Replaced the download link to the newest version of discord, instead of downloading a specific version.
Solves #2 